### PR TITLE
Fix month format: "%B" to "%b"

### DIFF
--- a/TSTut3.ipynb
+++ b/TSTut3.ipynb
@@ -285,7 +285,7 @@
     "flight_df['day']='01'\n",
     "\n",
     "# We need to turn the month names to integers\n",
-    "flight_df['month'] = pd.to_datetime(flight_df.month, format='%B').dt.month\n",
+    "flight_df['month'] = pd.to_datetime(flight_df.month, format='%b').dt.month\n",
     "# Create a date column with our new dates\n",
     "flight_df['date'] = pd.to_datetime(flight_df[['year', 'month', 'day']])\n",
     "# Delete year, month and day columns\n",

--- a/TSTut4.ipynb
+++ b/TSTut4.ipynb
@@ -310,7 +310,7 @@
     "# we will use it (See last video for what this is doing in detail)\n",
     "flight_df = sns.load_dataset('flights')\n",
     "flight_df['day']='01'\n",
-    "flight_df['month'] = pd.to_datetime(flight_df.month, format='%B').dt.month\n",
+    "flight_df['month'] = pd.to_datetime(flight_df.month, format='%b').dt.month\n",
     "flight_df['date'] = pd.to_datetime(flight_df[['year', 'month', 'day']])\n",
     "flight_df.drop(['year', 'month', 'day'], axis=1, inplace=True)\n",
     "flight_df.set_index('date', inplace=True)\n",


### PR DESCRIPTION
At two places, using the month format `%B` gives a value error.
```
ValueError: time data 'Jan' does not match format '%B' (match)
```

<details><summary>Full Error Log from TSTut3.py</summary>
<p>

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/.local/lib/python3.8/site-packages/pandas/core/tools/datetimes.py in _convert_listlike_datetimes(arg, format, name, tz, unit, errors, infer_datetime_format, dayfirst, yearfirst, exact)
    449             try:
--> 450                 values, tz = conversion.datetime_to_datetime64(arg)
    451                 dta = DatetimeArray(values, dtype=tz_to_dtype(tz))

pandas/_libs/tslibs/conversion.pyx in pandas._libs.tslibs.conversion.datetime_to_datetime64()

TypeError: Unrecognized value type: <class 'str'>

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
<ipython-input-4-060bce100111> in <module>
     17 
     18 # We need to turn the month names to integers
---> 19 flight_df['month'] = pd.to_datetime(flight_df.month, format='%B').dt.month
     20 # Create a date column with our new dates
     21 flight_df['date'] = pd.to_datetime(flight_df[['year', 'month', 'day']])

~/.local/lib/python3.8/site-packages/pandas/core/tools/datetimes.py in to_datetime(arg, errors, dayfirst, yearfirst, utc, format, exact, unit, infer_datetime_format, origin, cache)
    801             result = arg.map(cache_array)
    802         else:
--> 803             values = convert_listlike(arg._values, format)
    804             result = arg._constructor(values, index=arg.index, name=arg.name)
    805     elif isinstance(arg, (ABCDataFrame, abc.MutableMapping)):

~/.local/lib/python3.8/site-packages/pandas/core/tools/datetimes.py in _convert_listlike_datetimes(arg, format, name, tz, unit, errors, infer_datetime_format, dayfirst, yearfirst, exact)
    452                 return DatetimeIndex._simple_new(dta, name=name)
    453             except (ValueError, TypeError):
--> 454                 raise e
    455 
    456     if result is None:

~/.local/lib/python3.8/site-packages/pandas/core/tools/datetimes.py in _convert_listlike_datetimes(arg, format, name, tz, unit, errors, infer_datetime_format, dayfirst, yearfirst, exact)
    415             if result is None:
    416                 try:
--> 417                     result, timezones = array_strptime(
    418                         arg, format, exact=exact, errors=errors
    419                     )

pandas/_libs/tslibs/strptime.pyx in pandas._libs.tslibs.strptime.array_strptime()

ValueError: time data 'Jan' does not match format '%B' (match)
```

</p>
</details>

As per [this webpage](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Period.strftime.html), `%b` should be used for abbreviated month names and `%B` for full month names.

And many many thanks for your video on Data Science! :heart: